### PR TITLE
twilio styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~testdata/*
 *~
 secrets.json
+.vscode/*

--- a/html/client.html
+++ b/html/client.html
@@ -25,17 +25,29 @@
          }
          .participants {
              width: 99vw;
-             height: 117px;
+             max-height: 216px;
              position: absolute;
              bottom: 0;
+             display: flex;
+             flex-wrap: wrap-reverse;
+             overflow: hidden;
+         }
+         .participant-video-wrapper {
+             margin: 2px;
+             flex: 1 1 100px;
+             margin: 2px;
+             margin-top:8px;
          }
          .participant-video {
              width: 100px;
              height: 100px;
-             border-radius: 50%;
+             background: black;
+             border: solid 1px rgba(255,255,200,.75);
+             background: black;
          }
          body {
              background-color: black;
+             margin:0;
          }
          #ctrls {
              position: absolute;

--- a/html/lib.js
+++ b/html/lib.js
@@ -301,7 +301,9 @@ export function setMuted(mut) {
 }
 
 function addVideoCircle(track) {
-    $(track.attach()).addClass('participant-video').appendTo('#participants');
+    let wrapper = $('<div>').addClass('participant-video-wrapper')
+    $(track.attach()).addClass('participant-video').appendTo(wrapper);
+    wrapper.appendTo("#participants")
 }
 
 function listenToAudio(track) {


### PR DESCRIPTION
Changes Twilio to be rectangles, styled vaguely after the images on secularsolstice.com. Uses flexbox to make them wrap reasonably sensibly. Uses max-height to allow up to two rows of them (this probably _also_ wants to be handled in the Twilio backend but seemed good to have a css-failsafe)

After experimenting with the circle-versions, i felt like they needed to be square because I kept being sad that large chunks of me were cropped off and I had to work extra hard to keep my face centered, or resign myself to not really being captured by the camera.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3246710/100492988-5796a080-30e7-11eb-91a4-e68bccb41f8d.png">
