### PR TITLE
Make homepage redirect to currently active ritual

### DIFF
--- a/rituals.py
+++ b/rituals.py
@@ -23,6 +23,9 @@ except KeyError:
     intercom_app_id = ''
 
 async def homepage(req):
+    if len(active) == 1 and 'controlpanel' not in req.query:
+        ritual_name, = active.keys()
+        raise web.HTTPFound(f'/{ritual_name}/partake')
     l = '\n'.join([ '<li><a href="/%s/partake">%s (%s)</a>'%(x,x,active[x].script) for x in active.keys() ])
     s = '\n'.join([ '<option>%s</option>'%(x.replace('examples/','')) for x in glob('examples/*') ])
     html = tpl('html/index.html', list=l, scripts=s)


### PR DESCRIPTION
This does not occur if there isn't exactly one active ritual. It can also be worked around by going to /?controlpanel.

Users are likely to wind up on the root of the site and we don't want them clicking things in the control panel.