### PR TITLE
Explicitly catch and handle errors thrown by Twilio.Video.createLocalAudioTrack in avatars.js

### DIFF
--- a/html/avatars.js
+++ b/html/avatars.js
@@ -499,14 +499,14 @@ export async function twilioConnect(token, roomId) {
         localVideo = null;
     }
     if ( ! localAudioTrack) {
-        let res;
-        let p = new Promise((r)=>{res=r;});
-        Twilio.Video.createLocalAudioTrack().then((lat)=>{
-            localAudioTrack = lat;
-            res();
-        }).catch((e)=>{throw e;});
-        setTimeout(res, 3000);
-        await p;
+        localAudioTrack = await Promise.race([
+            Twilio.Video.createLocalAudioTrack().catch(() => null),
+            new Promise((res) => {
+                setTimeout(() => {
+                    res(null);
+                }, 5000);
+            }),
+        ]);
         if (localAudioTrack) {
             localAudioTrack.disable();
         } else if (!retrieveParameter("got_mic_warning")) {

--- a/widgets/BucketSinging.js
+++ b/widgets/BucketSinging.js
@@ -114,11 +114,14 @@ async function initContext(){
 
     div.append('Searching for microphone...');
 
-    let res;
-    let p = new Promise((r)=>{res=r});
-    (new MicEnumerator()).mics().then(res);
-    setTimeout(res.bind(null,[]), 2000);
-    let mics = await p;
+    let mics = await Promise.race([
+        new MicEnumerator().mics(),
+        new Promise((res) => {
+            setTimeout(() => {
+                res([]);
+            }, 2000);
+        })
+    ]);
 
     if (mics.length == 0) {
         const got_mic_warning = retrieveParameter("got_mic_warning");


### PR DESCRIPTION
While we're at it, also clean up the one other place in the code that's using a similar pattern, though in this case I don't think the existing code is actually at risk of throwing exceptions.

And bump the timeout to 5 seconds per decision in videoconference.

Fixes: #202
Fixes: #220 (not really but it works around it)